### PR TITLE
[TASK-31] implement-i18n-messages

### DIFF
--- a/frontend/src/__tests__/events/game/testHandleStartGame.ts
+++ b/frontend/src/__tests__/events/game/testHandleStartGame.ts
@@ -1,6 +1,7 @@
 import "../setupTests";
 import { handleStartGame } from "@/events/game/handlers/startGame";
 import { Game } from "@/interfaces/Lobby";
+import { i18n } from "@/plugins/i18n";
 
 describe('handleStartGame', () => {
   const leaderPlayer = {
@@ -48,7 +49,7 @@ describe('handleStartGame', () => {
   });
 
   test('Deve emitir um erro se o jogador atual não estiver em um lobby', () => {
-    expect(() => handleStartGame()).toThrow('Você não está em um lobby !');
+    expect(() => handleStartGame()).toThrow(Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY')));
   });
 
   test('Deve emitir um erro se um jogo já estiver começado no lobby atual do jogador', () => {
@@ -68,6 +69,6 @@ describe('handleStartGame', () => {
     }
 
     expect(() => handleStartGame())
-      .toThrow(Error('Não foi possível iniciar o jogo: O jogo já começou !'))
+      .toThrow(Error(i18n.t('COMMON.ERROR.GAME_ALREADY_STARTED')))
   })
 });

--- a/frontend/src/__tests__/events/lobby/testHandleJoinLobbySuccess.ts
+++ b/frontend/src/__tests__/events/lobby/testHandleJoinLobbySuccess.ts
@@ -1,8 +1,9 @@
 
 
 import "../setupTests";
+import type Lobby from "@/interfaces/Lobby";
 import { handleJoinLobbySuccess } from "@/events/lobby/handlers/joinLobbySuccess";
-import Lobby from "@/interfaces/Lobby";
+import { i18n } from "@/plugins/i18n";
 
 describe("handleJoinLobbySuccess", () => {
 
@@ -36,6 +37,6 @@ describe("handleJoinLobbySuccess", () => {
         }
         require('@/connection').lobby.value = lobbyParam  // Variável global de lobby definida marca que jogador já está em um lobby, e não poderia entrar em outro.
 
-        expect(() => handleJoinLobbySuccess(lobbyParam)).toThrow(Error)
+        expect(() => handleJoinLobbySuccess(lobbyParam)).toThrow(Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY')))
     })
 })

--- a/frontend/src/__tests__/events/lobby/testHandleJoinLobbySuccess.ts
+++ b/frontend/src/__tests__/events/lobby/testHandleJoinLobbySuccess.ts
@@ -37,6 +37,6 @@ describe("handleJoinLobbySuccess", () => {
         }
         require('@/connection').lobby.value = lobbyParam  // Variável global de lobby definida marca que jogador já está em um lobby, e não poderia entrar em outro.
 
-        expect(() => handleJoinLobbySuccess(lobbyParam)).toThrow(Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY')))
+        expect(() => handleJoinLobbySuccess(lobbyParam)).toThrow(Error(i18n.t('COMMON.ERROR.ALREADY_IN_LOBBY')))
     })
 })

--- a/frontend/src/__tests__/events/lobby/testHandlePlayerJoin.ts
+++ b/frontend/src/__tests__/events/lobby/testHandlePlayerJoin.ts
@@ -1,6 +1,7 @@
 import '../setupTests';
+import type { Game } from '@/interfaces/Lobby';
 import { handlePlayerJoin } from '@/events/lobby/handlers/playerJoin';
-import { Game } from '@/interfaces/Lobby';
+import { i18n } from '@/plugins/i18n';
 
 describe('handlePlayerJoin', () => {
   const leaderPlayer = {
@@ -47,7 +48,7 @@ describe('handlePlayerJoin', () => {
 
   test('Deve emitir um erro se o jogador não estiver em um lobby', () => {
     expect(() => handlePlayerJoin(anotherPlayer.id, anotherPlayer.name))
-      .toThrow(Error('Você não está em um lobby !'))
+      .toThrow(Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY')))
   })
 
   test('Deve emitir um erro se um jogo já estiver começado no lobby atual do jogador', () => {
@@ -67,6 +68,6 @@ describe('handlePlayerJoin', () => {
     }
 
     expect(() => handlePlayerJoin(anotherPlayer.id, anotherPlayer.name))
-      .toThrow(Error('Não foi possível adicionar um novo jogador ao seu lobby atual, o jogo já começou !'))
+      .toThrow(Error(i18n.t('COMMON.ERROR.GAME_ALREADY_STARTED')))
   })
 })

--- a/frontend/src/__tests__/events/lobby/testHandlePlayerLogout.ts
+++ b/frontend/src/__tests__/events/lobby/testHandlePlayerLogout.ts
@@ -1,6 +1,7 @@
 import '../setupTests';
+import type Lobby from '@/interfaces/Lobby';
 import { handlePlayerLogout } from '@/events/lobby/handlers/playerLogout';
-import Lobby from '@/interfaces/Lobby';
+import { i18n } from '@/plugins/i18n';
 
 describe('handlePlayerLogout', () => {
   const leaderPlayer = {
@@ -54,7 +55,8 @@ describe('handlePlayerLogout', () => {
   });
 
   test('Deve emitir um erro se o jogador atual não estiver em um lobby', () => {
-    expect(() => handlePlayerLogout(leaderPlayer.id)).toThrow('Você não está em um lobby !');
+    expect(() => handlePlayerLogout(leaderPlayer.id))
+      .toThrow(Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY')));
   });
 
   test('Deve emitir um erro se o jogador informado não estiver no lobby', () => {
@@ -67,6 +69,6 @@ describe('handlePlayerLogout', () => {
     };
 
     expect(() => handlePlayerLogout(anotherPlayer.id))
-      .toThrow('Não foi possível remover o jogador do lobby atual: Jogador não encontrado !');
+      .toThrow(Error(i18n.t('COMMON.ERROR.PLAYER_NOT_FOUND')));
   });
 });

--- a/frontend/src/__tests__/events/lobby/testHandlePlayerReady.ts
+++ b/frontend/src/__tests__/events/lobby/testHandlePlayerReady.ts
@@ -1,6 +1,7 @@
 import '../setupTests';
-import { handlePlayerReady } from '@/events/lobby/handlers/playerReady';
 import Lobby, { Game } from '@/interfaces/Lobby';
+import { handlePlayerReady } from '@/events/lobby/handlers/playerReady';
+import { i18n } from '@/plugins/i18n';
 
 describe('handlePlayerReady', () => {
   const readyPlayer = {
@@ -36,7 +37,8 @@ describe('handlePlayerReady', () => {
   });
 
   test('Deve emitir um erro se o jogador atual não estiver em um lobby', () => {
-    expect(() => handlePlayerReady(unreadyPlayer.id)).toThrow('Você não está em um lobby !');
+    expect(() => handlePlayerReady(unreadyPlayer.id))
+      .toThrow(Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY')));
   });
 
   test('Deve emitir um erro se um jogo já estiver começado no lobby atual do jogador', () => {
@@ -56,7 +58,7 @@ describe('handlePlayerReady', () => {
     }
 
     expect(() => handlePlayerReady(unreadyPlayer.id))
-      .toThrow(Error('Não foi possível atualizar o status de um jogador para preparado: O jogo já começou !'))
+      .toThrow(Error(i18n.t('COMMON.ERROR.GAME_ALREADY_STARTED')))
   })
 
   test('Deve emitir um erro se o jogador informado não estiver no lobby', () => {
@@ -69,6 +71,6 @@ describe('handlePlayerReady', () => {
     };
 
     expect(() => handlePlayerReady(unreadyPlayer.id))
-      .toThrow('Não foi possível atualizar o status de um jogador para preparado: Jogador não encontrado !');
+      .toThrow(Error(i18n.t('COMMON.ERROR.PLAYER_NOT_FOUND')));
   });
 });

--- a/frontend/src/__tests__/events/lobby/testHandlePlayerUnready.ts
+++ b/frontend/src/__tests__/events/lobby/testHandlePlayerUnready.ts
@@ -1,6 +1,7 @@
 import '../setupTests';
-import { handlePlayerUnready } from '@/events/lobby/handlers/playerUnready';
 import Lobby, { Game } from '@/interfaces/Lobby';
+import { handlePlayerUnready } from '@/events/lobby/handlers/playerUnready';
+import { i18n } from '@/plugins/i18n';
 
 describe('handlePlayerUnready', () => {
   const readyPlayer = {
@@ -36,7 +37,8 @@ describe('handlePlayerUnready', () => {
   });
 
   test('Deve emitir um erro se o jogador atual não estiver em um lobby', () => {
-    expect(() => handlePlayerUnready(unreadyPlayer.id)).toThrow('Você não está em um lobby !');
+    expect(() => handlePlayerUnready(unreadyPlayer.id))
+      .toThrow(Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY')));
   });
 
   test('Deve emitir um erro se um jogo já estiver começado no lobby atual do jogador', () => {
@@ -56,7 +58,7 @@ describe('handlePlayerUnready', () => {
     }
 
     expect(() => handlePlayerUnready(readyPlayer.id))
-      .toThrow(Error('Não foi possível atualizar o status de um jogador para não preparado: O jogo já começou !'))
+      .toThrow(Error(i18n.t('COMMON.ERROR.GAME_ALREADY_STARTED')))
   })
 
   test('Deve emitir um erro se o jogador informado não estiver no lobby', () => {
@@ -69,6 +71,6 @@ describe('handlePlayerUnready', () => {
     };
 
     expect(() => handlePlayerUnready(readyPlayer.id))
-      .toThrow('Não foi possível atualizar o status de um jogador para não preparado: Jogador não encontrado !');
+      .toThrow(Error(i18n.t('COMMON.ERROR.PLAYER_NOT_FOUND')));
   });
 });

--- a/frontend/src/events/game/handlers/startGame.ts
+++ b/frontend/src/events/game/handlers/startGame.ts
@@ -1,5 +1,6 @@
-import { lobby } from '@/connection';
 import type { Game } from '@/interfaces/Lobby';
+import { lobby } from '@/connection';
+import { i18n } from '@/plugins/i18n';
 
 const INITIAL_HEALTH = 3;
 const INITIAL_WAIT_TIME = 5;
@@ -11,11 +12,11 @@ const INITIAL_ROUND_NUMBER = 1;
  */
 export function handleStartGame() {
   if (lobby.value === null) {
-    throw new Error('Você não está em um lobby !');
+    throw new Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY'));
   }
 
   if (lobby.value.game) {
-    throw new Error('Não foi possível iniciar o jogo: O jogo já começou !');
+    throw new Error(i18n.t('COMMON.ERROR.GAME_ALREADY_STARTED'));
   }
 
   const players = lobby.value.players as Array<{ id: string }>;

--- a/frontend/src/events/lobby/handlers/joinLobbySuccess.ts
+++ b/frontend/src/events/lobby/handlers/joinLobbySuccess.ts
@@ -1,7 +1,7 @@
 
 import type Lobby from "@/interfaces/Lobby";
 import { lobby } from '@/connection'
-
+import { i18n } from "@/plugins/i18n";
 
 /**
  *  Indica ao usuário que ele conseguiu entrar na sala.
@@ -13,7 +13,7 @@ import { lobby } from '@/connection'
  */
 export function handleJoinLobbySuccess(lobbyResponse: Lobby) {
     if (lobby.value !== null) {
-        throw new Error('Usuário já está em um lobby !')
+        throw new Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY'))
     }
 
     lobby.value = lobbyResponse

--- a/frontend/src/events/lobby/handlers/joinLobbySuccess.ts
+++ b/frontend/src/events/lobby/handlers/joinLobbySuccess.ts
@@ -13,7 +13,7 @@ import { i18n } from "@/plugins/i18n";
  */
 export function handleJoinLobbySuccess(lobbyResponse: Lobby) {
     if (lobby.value !== null) {
-        throw new Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY'))
+        throw new Error(i18n.t('COMMON.ERROR.ALREADY_IN_LOBBY'))
     }
 
     lobby.value = lobbyResponse

--- a/frontend/src/events/lobby/handlers/playerJoin.ts
+++ b/frontend/src/events/lobby/handlers/playerJoin.ts
@@ -1,6 +1,6 @@
 
-import { lobby } from '@/connection'
-
+import { lobby } from '@/connection';
+import { i18n } from '@/plugins/i18n';
 
 /**
  *  Evento enviado para todos os jogadores indicando que um novo jogador entrou na sala.
@@ -10,11 +10,11 @@ import { lobby } from '@/connection'
  */
 export function handlePlayerJoin(id: string, name: string) {
   if (lobby.value === null) {
-    throw new Error('Você não está em um lobby !');
+    throw new Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY'));
   }
 
   if (lobby.value.game) {
-    throw new Error('Não foi possível adicionar um novo jogador ao seu lobby atual, o jogo já começou !');
+    throw new Error(i18n.t('COMMON.ERROR.GAME_ALREADY_STARTED'));
   }
 
   lobby.value.players.push({

--- a/frontend/src/events/lobby/handlers/playerLogout.ts
+++ b/frontend/src/events/lobby/handlers/playerLogout.ts
@@ -1,5 +1,6 @@
 
-import { lobby, socket } from '@/connection'
+import { lobby, socket } from '@/connection';
+import { i18n } from '@/plugins/i18n';
 
 /**
  *  Evento indicando que um jogador acaba de sair da sala.
@@ -8,12 +9,12 @@ import { lobby, socket } from '@/connection'
  */
 export function handlePlayerLogout(id: string) {
   if (lobby.value === null) {
-    throw new Error('Você não está em um lobby !');
+    throw new Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY'));
   }
 
   const playerIndex = lobby.value.players.findIndex((player) => player.id === id);
   if (playerIndex === -1) {
-    throw new Error('Não foi possível remover o jogador do lobby atual: Jogador não encontrado !');
+    throw new Error(i18n.t('COMMON.ERROR.PLAYER_NOT_FOUND'));
   }
 
   lobby.value.players.splice(playerIndex, 1);

--- a/frontend/src/events/lobby/handlers/playerReady.ts
+++ b/frontend/src/events/lobby/handlers/playerReady.ts
@@ -1,5 +1,6 @@
 
-import { lobby } from '@/connection'
+import { lobby } from '@/connection';
+import { i18n } from '@/plugins/i18n';
 
 /**
  *  Indica que um jogador acaba de ficar preparado para um jogo.
@@ -9,16 +10,16 @@ import { lobby } from '@/connection'
  */
 export function handlePlayerReady(id: string) {
   if (lobby.value === null) {
-    throw new Error('Você não está em um lobby !');
+    throw new Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY'));
   }
 
   if (lobby.value.game) {
-    throw new Error('Não foi possível atualizar o status de um jogador para preparado: O jogo já começou !');
+    throw new Error(i18n.t('COMMON.ERROR.GAME_ALREADY_STARTED'));
   }
 
   const playerIndex = lobby.value.players.findIndex((player) => player.id === id);
   if (playerIndex === -1) {
-    throw new Error('Não foi possível atualizar o status de um jogador para preparado: Jogador não encontrado !');
+    throw new Error(i18n.t('COMMON.ERROR.PLAYER_NOT_FOUND'));
   }
 
   lobby.value.players[playerIndex].ready = true;

--- a/frontend/src/events/lobby/handlers/playerUnready.ts
+++ b/frontend/src/events/lobby/handlers/playerUnready.ts
@@ -1,6 +1,6 @@
 
-import { lobby } from '@/connection'
-
+import { lobby } from '@/connection';
+import { i18n } from '@/plugins/i18n';
 
 /**
  *  Indica que um jogador acaba de ficar despreparado para um jogo.
@@ -10,16 +10,16 @@ import { lobby } from '@/connection'
  */
 export function handlePlayerUnready(id: string) {
   if (lobby.value === null) {
-    throw new Error('Você não está em um lobby !');
+    throw new Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY'));
   }
 
   if (lobby.value.game) {
-    throw new Error('Não foi possível atualizar o status de um jogador para não preparado: O jogo já começou !');
+    throw new Error(i18n.t('COMMON.ERROR.GAME_ALREADY_STARTED'));
   }
 
   const playerIndex = lobby.value.players.findIndex((player) => player.id === id);
   if (playerIndex === -1) {
-    throw new Error('Não foi possível atualizar o status de um jogador para não preparado: Jogador não encontrado !');
+    throw new Error(i18n.t('COMMON.ERROR.PLAYER_NOT_FOUND'));
   }
 
   lobby.value.players[playerIndex].ready = false;

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -1,6 +1,7 @@
 {
   "COMMON": {
     "ERROR": {
+      "ALREADY_IN_LOBBY": "Você já está em um lobby!",
       "NOT_IN_LOBBY": "Você não está em um lobby!",
       "GAME_ALREADY_STARTED": "O jogo já começou!",
       "PLAYER_NOT_FOUND": "Jogador não encontrado!"

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -1,6 +1,9 @@
 {
-  "COMMONS": {
-    "NOT_IN_LOBBY": "Você não está em um lobby !",
-    "GAME_ALREADY_STARTED": "O jogo já começou !"
+  "COMMON": {
+    "ERROR": {
+      "NOT_IN_LOBBY": "Você não está em um lobby!",
+      "GAME_ALREADY_STARTED": "O jogo já começou!",
+      "PLAYER_NOT_FOUND": "Jogador não encontrado!"
+    }
   }
 }

--- a/frontend/src/plugins/i18n.ts
+++ b/frontend/src/plugins/i18n.ts
@@ -5,7 +5,7 @@ type MessageSchema  = typeof ptBR;
 
 const environment = process.env.NODE_ENV
 
-const i18n = createI18n<[MessageSchema], 'pt-BR'>({
+const I18n = createI18n<[MessageSchema], 'pt-BR'>({
   // For use with Vue Composition API
   legacy: false,
   // Hide warnings only for test environment
@@ -16,4 +16,6 @@ const i18n = createI18n<[MessageSchema], 'pt-BR'>({
   }
 });
 
-export default i18n;
+export const i18n = I18n.global;
+
+export default I18n;


### PR DESCRIPTION
Esse PR contém a adição das mensagens com i18n para os `eventHandlers` já implementados

Aproveitando que passei por vários arquivos, padronizei a ordem de importação dos módulos.
Também garanti que todas as chamadas de `toThrow()` recebam uma mensagem especifica de `Error()`. (`toThrow(Error('message'))` em vez de só `toThrow('message')`.