### PR TITLE
[TASK-45] start-new-game

### DIFF
--- a/backend/src/__tests__/events/game/startNewGame.test.ts
+++ b/backend/src/__tests__/events/game/startNewGame.test.ts
@@ -1,0 +1,54 @@
+
+import { player, lobbyClientsSockets, createLobby } from '../setupTests';
+import i18n from '../../../plugins/i18n';
+import { startNewGame } from '../../../events/game/functions/startNewGame';
+import { startNewMatch } from '../../../events/match/functions/startNewMatch';
+
+jest.mock('../../../events/match/functions/startNewMatch.ts');
+
+describe('startNewGame', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('Deve criar o objeto Game corretamente', () => {
+    createLobby();
+
+    startNewGame(player);
+
+    expect(player.lobby?.game?.matchNumber).toBe(1);
+    expect(player.lobby?.game?.roundNumber).toBe(1);
+    expect(player.lobby?.game?.currentPlayerId).toBe(player?.lobby?.players[player.lobby.players.length - 1].id);
+    expect(player.lobby?.game?.status).toBe('starting_match');
+    expect(player.lobby?.game?.deadPlayersIds).toEqual([]);
+    expect(player.lobby?.game?.numRounds).toBe(1);
+    expect(player.lobby?.game?.playersHealth).toEqual({
+      [player.playerId]: 3,
+      [lobbyClientsSockets[0].id!]: 3
+    });
+
+    // Testing timer
+    expect(player.lobby?.game?.timer.getConfig().countdown).toBe(true);
+    expect(player.lobby?.game?.timer.getTimeValues().seconds).toBe(5);
+    jest.advanceTimersByTime(5000);
+    expect(startNewMatch).toHaveBeenCalledWith(player);
+  });
+
+  test('Deve enviar mensagem de incio de jogo para todos os jogadores', () => {
+    createLobby();
+
+    const emitSpy = jest.spyOn(player.eventsEmitter.Game, 'emitStartGame');
+
+    startNewGame(player);
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('Deve lançar uma exceção caso o jogador não esteja em um lobby', () => {
+    expect(() => startNewGame(player)).toThrow(new Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY')));
+  });
+});

--- a/backend/src/__tests__/events/game/startNewGame.test.ts
+++ b/backend/src/__tests__/events/game/startNewGame.test.ts
@@ -38,7 +38,7 @@ describe('startNewGame', () => {
     expect(startNewMatch).toHaveBeenCalledWith(player);
   });
 
-  test('Deve enviar mensagem de incio de jogo para todos os jogadores', () => {
+  test('Deve enviar mensagem de início de jogo para todos os jogadores', () => {
     createLobby();
 
     const emitSpy = jest.spyOn(player.eventsEmitter.Game, 'emitStartGame');

--- a/backend/src/__tests__/events/setupTests.ts
+++ b/backend/src/__tests__/events/setupTests.ts
@@ -66,6 +66,9 @@ afterEach(() => {
   }
   clientSocket.removeAllListeners('player-join');
   lobbyClientsSockets[0].removeAllListeners('player-join');
+
+  player.lobby = undefined;
+  player.eventsEmitter = new EventsEmitter(io, player.socket);
 });
 
 afterAll(() => {
@@ -77,4 +80,28 @@ afterAll(() => {
   }
 });
 
-export { io, clientSocket, serverSocket, player, eventsEmitter, lobbyClientsSockets, lobbyServerSockets };
+function createLobby() {
+  lobbys['123'] = {
+    lobbyId: '123',
+    players: [
+      {
+        id: player.playerId,
+        name: 'player1',
+        leader: true,
+        ready: true,
+      },
+      {
+        id: lobbyServerSockets[0].id!,
+        name: 'player2',
+        leader: false,
+        ready: true
+      }
+    ]
+  };
+  player.lobby = lobbys['123'];
+  player.eventsEmitter = new EventsEmitter(io, player.socket, '123');
+  players[player.playerId] = { socket: player.socket, lobby: lobbys['123'] };
+  players[lobbyServerSockets[0].id!] = { socket: lobbyServerSockets[0], lobby: lobbys['123'] };
+}
+
+export { io, clientSocket, serverSocket, player, eventsEmitter, lobbyClientsSockets, lobbyServerSockets, createLobby };

--- a/backend/src/events/EmitterBase.ts
+++ b/backend/src/events/EmitterBase.ts
@@ -66,7 +66,7 @@ export default class EmitterBase {
     }
   }
 
-  public get playerInLobby() {
+  public get isPlayerInLobby() {
     return this.lobbyId !== undefined;
   }
 }

--- a/backend/src/events/EmitterBase.ts
+++ b/backend/src/events/EmitterBase.ts
@@ -65,4 +65,8 @@ export default class EmitterBase {
       throw new Error(`Jogador de id ${this.socket.id} tentou emitir um evento para a sala, mas não está em nenhuma sala.`);
     }
   }
+
+  public get playerInLobby() {
+    return this.lobbyId !== undefined;
+  }
 }

--- a/backend/src/events/game/functions/startNewGame.ts
+++ b/backend/src/events/game/functions/startNewGame.ts
@@ -14,8 +14,6 @@ import { startNewMatch } from '../../match/functions/startNewMatch';
  *
  *  @param player jogador que iniciou o jogo (líder)
  */
-// Remover comentário abaixo quando implementar a função, juntamente com esse comentário atual
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function startNewGame(player: Player): void {
   const lobby = player.lobby;
   if (!lobby) {

--- a/backend/src/events/game/functions/startNewGame.ts
+++ b/backend/src/events/game/functions/startNewGame.ts
@@ -1,6 +1,8 @@
 
 import { Game } from '../../../interfaces/Lobby';
 import Player from '../../../interfaces/Player';
+import { generateInternalServerError } from '../../general/functions/generateInternalServerError';
+import i18n from '../../../plugins/i18n';
 
 /**
  *  Função que começa um jogo de "little-fuck". Essa função é responsável por:
@@ -14,5 +16,7 @@ import Player from '../../../interfaces/Player';
 // Remover comentário abaixo quando implementar a função, juntamente com esse comentário atual
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function startNewGame(player: Player): Game {
-
+  if (!player.lobby) {
+    generateInternalServerError(i18n.t('COMMON.ERROR.NOT_IN_LOBBY'));
+  }
 }

--- a/backend/src/events/game/functions/startNewGame.ts
+++ b/backend/src/events/game/functions/startNewGame.ts
@@ -1,22 +1,48 @@
 
-import { Game } from '../../../interfaces/Lobby';
 import Player from '../../../interfaces/Player';
-import { generateInternalServerError } from '../../general/functions/generateInternalServerError';
 import i18n from '../../../plugins/i18n';
+import Timer from 'easytimer.js';
+import { startNewMatch } from '../../match/functions/startNewMatch';
 
 /**
  *  Função que começa um jogo de "little-fuck". Essa função é responsável por:
- *  - Criar a versão inicial do objeto Game
+ *  - Criar a versão inicial do objeto Game (de forma in-place, ou seja, modifica o objeto `player.lobby` diretamente)
  *  - Enviar mensagens para todos os jogadores que o jogo começou
  *  - Cadastrar um timer para o início de uma partida
  *
+ *  OBS: pode lançar uma exceção caso o jogador não esteja em um lobby
+ *
  *  @param player jogador que iniciou o jogo (líder)
- *  @returns um objeto do tipo Game, contendo as informações iniciais necessárias para o começo do jogo.
  */
 // Remover comentário abaixo quando implementar a função, juntamente com esse comentário atual
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function startNewGame(player: Player): Game {
-  if (!player.lobby) {
-    generateInternalServerError(i18n.t('COMMON.ERROR.NOT_IN_LOBBY'));
+export function startNewGame(player: Player): void {
+  const lobby = player.lobby;
+  if (!lobby) {
+    throw new Error(i18n.t('COMMON.ERROR.NOT_IN_LOBBY'));
   }
+
+  const playersHealth: { [playerId: string]: number} = {};
+  for (const player of lobby.players) {
+    playersHealth[player.id] = 3;
+  }
+
+  const timer = new Timer();
+  timer.start({ countdown: true, startValues: { seconds: 5 } });
+  timer.addEventListener('targetAchieved', () => {
+    startNewMatch(player);
+  });
+
+  lobby.game = {
+    matchNumber: 1,
+    roundNumber: 1,
+    currentPlayerId: lobby.players[lobby.players.length - 1].id,
+    status: 'starting_match',
+    deadPlayersIds: [],
+    numRounds: 1,
+    playersHealth,
+    timer,
+  };
+
+  player.eventsEmitter.Game.emitStartGame();
 }

--- a/backend/src/events/general/eventsEmitter.ts
+++ b/backend/src/events/general/eventsEmitter.ts
@@ -33,7 +33,7 @@ export default class GeneralEventsEmitter extends EmitterBase {
      *  e um log desse evento será feito no servidor para posterior correção...
      */
   public emitInternalServerError() {
-    if (this.playerInLobby) {
+    if (this.isPlayerInLobby) {
       this.emitToLobby('internal-server-error');
     } else {
       this.emitToUser('internal-server-error');

--- a/backend/src/events/general/eventsEmitter.ts
+++ b/backend/src/events/general/eventsEmitter.ts
@@ -33,6 +33,10 @@ export default class GeneralEventsEmitter extends EmitterBase {
      *  e um log desse evento será feito no servidor para posterior correção...
      */
   public emitInternalServerError() {
-    this.emitToLobby('internal-server-error');
+    if (this.playerInLobby) {
+      this.emitToLobby('internal-server-error');
+    } else {
+      this.emitToUser('internal-server-error');
+    }
   }
 }

--- a/backend/src/events/general/functions/generateInternalServerError.ts
+++ b/backend/src/events/general/functions/generateInternalServerError.ts
@@ -1,13 +1,16 @@
 
+import Player from '../../../interfaces/Player';
+
 /**
  *  Essa função deve ser chamada quando ocorrer um erro inesperado no servidor. Essa função irá informar os clientes da ocorrência
  *  do erro, finalizando o lobby de todos os jogadores (para não ocorrer erros piores, podendo "crashar" o servidor). Também
  *  registra o erro no console do servidor.
  *
- *  @param errorMessage Mensagem de erro que será registrada no console do servidor.
+ *  @param player Player que será usado para emitir o evento de erro para o(s) cliente(s).
+ *  @param error Erro que será registrado no console do servidor.
  */
 // Remover comentário abaixo quando implementar a função, juntamente com esse comentário atual
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function generateInternalServerError(errorMessage: Error): void {
+export function generateInternalServerError(player: Player, error: Error): void {
 
 }

--- a/backend/src/events/match/functions/startNewMatch.ts
+++ b/backend/src/events/match/functions/startNewMatch.ts
@@ -1,9 +1,9 @@
-import { Match } from '../../../interfaces/Lobby';
+
 import Player from '../../../interfaces/Player';
 
 /**
  *  Função que começa uma partida de "little-fuck". Essa função é responsável por:
- *  - Criar um objeto Match
+ *  - Criar um objeto Match (de forma in-place, ou seja, modifica o objeto `player.lobby` diretamente)
  *  - Enviar mensagens para todos os jogadores que a partida começou
  *  - Cadastrar um timer para que o primeiro jogador faça o palpite automaticamente caso ele não palpite a tempo
  *
@@ -12,6 +12,6 @@ import Player from '../../../interfaces/Player';
  */
 // Remover comentário abaixo quando implementar a função, juntamente com esse comentário atual
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function startNewMatch(player: Player): Match {
+export function startNewMatch(player: Player): void {
 
 }

--- a/backend/src/events/round/functions/startNewRound.ts
+++ b/backend/src/events/round/functions/startNewRound.ts
@@ -1,4 +1,4 @@
-import { Round } from '../../../interfaces/Lobby';
+
 import Player from '../../../interfaces/Player';
 
 /**

--- a/backend/src/events/round/functions/startNewRound.ts
+++ b/backend/src/events/round/functions/startNewRound.ts
@@ -3,7 +3,7 @@ import Player from '../../../interfaces/Player';
 
 /**
  *  Função que começa uma rodada de "little-fuck". Essa função é responsável por:
- *  - Criar um objeto Round
+ *  - Criar um objeto Round (de forma in-place, ou seja, modifica o objeto `player.lobby` diretamente)
  *  - Enviar mensagens para todos os jogadores que a rodada começou
  *  - Cadastrar um timer para que o primeiro jogador selecione a carta automaticamente caso ele não selecione a tempo
  *
@@ -12,6 +12,6 @@ import Player from '../../../interfaces/Player';
  */
 // Remover comentário abaixo quando implementar a função, juntamente com esse comentário atual
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function startNewRound(player: Player): Round {
+export function startNewRound(player: Player): void {
 
 }

--- a/backend/src/interfaces/Lobby.ts
+++ b/backend/src/interfaces/Lobby.ts
@@ -91,7 +91,7 @@ export interface Game {
     roundNumber: number,
     /** O id do jogador que iniciou palpitando na última (ou atual) partida */
     currentPlayerId: string,
-    /** Quantidade de rodadas (ou cartas) que devem ocorrer na última (ou atual) partida */
+    /** Quantidade de rodadas (ou cartas) que devem ocorrer na partida atual (ou que ocorreram na última partida) */
     numRounds: number,
     /** Lista de ids de jogadores que "morreram" (não possuem mais vidas / foram eliminados). Estará em ordem inversa de eliminação, ou seja, o primeiro da lista será o último que foi eliminado até o momento */
     deadPlayersIds: string[],


### PR DESCRIPTION
Além da implementação da própria tarefa, alguns outros pontos também foram melhorados/corrigidos:

- Funções startNewGame, startNewMatch, startNewRound:
     -  Antes era esperado que as funções de startNewGame, startNewMatch e startNewRound retornassem os objetos para depois fossem atribuidos em outro lugar. Porém, no local onde fosse receber esse retorno precisaria fazer verificações de existência de objetos (Exemplo: if (!player.lobby) ERRO e etc.).
Fica mais fácil fazer isso de forma in-place (a atribuição dentro da própria função), já que as verificações já precisam ser feitas lá de qualquer forma.
- correções generateInternalServerError
    - O generateInternalServerError precisa de alguma forma enviar mensagens de erro para os clientes, porém, não havia os parâmetros necessário na função.
   - Além disso, o erro nem sempre acontecerá com um jogador em um lobby, então o envio dessa mensagem foi corrigido para poder ser tanto para todos do lobby, quanto para apenas um jogador que não está em um lobby