### PR TITLE
[TASK-55] win-rounds-number-response

### DIFF
--- a/backend/src/__tests__/events/handlers.test.ts
+++ b/backend/src/__tests__/events/handlers.test.ts
@@ -37,6 +37,9 @@ jest.mock('../../events/match/functions/startNewMatch.ts', () => ({
   startNewMatch: jest.fn(),
 }));
 jest.mock('../../events/general/functions/generateInternalServerError.ts');
+jest.mock('../../index.ts', () => ({
+  io: 'mocked io',
+}));
 
 describe('Testes de recebimento de mensagem / eventos pelo servidor', () => {
 

--- a/backend/src/__tests__/events/match/handleWinRoundsNumberResponse.test.ts
+++ b/backend/src/__tests__/events/match/handleWinRoundsNumberResponse.test.ts
@@ -1,0 +1,234 @@
+
+import { lobbys, players } from '../../../global';
+
+import { player } from '../setupTests';
+import { Timer } from 'easytimer.js';
+import { generateInternalServerError } from '../../../events/general/functions/generateInternalServerError';
+import { handleWinRoundsNumberResponse } from '../../../events/match/handlers/winRoundsNumberResponse';
+import { checkValidFinalGuess } from '../../../events/match/functions/checkValidFinalGuess';
+import { getNextPlayerId } from '../../../events/functions/getNextPlayerId';
+import { generateAutomaticNumWinResponse } from '../../../events/match/functions/generateAutomaticNumWinResponse';
+import { startNewRound } from '../../../events/round/functions/startNewRound';
+import { endSpecialMatch } from '../../../events/match/functions/endSpecialMatch';
+
+const emitWinRoundsNumberUpdate = jest.fn();
+const emitWinRoundsNumberError = jest.fn();
+
+jest.mock('../../../events/general/functions/generateInternalServerError');
+jest.mock('../../../events/match/functions/checkValidFinalGuess', () => ({
+  checkValidFinalGuess: jest.fn(() => true),
+}));
+jest.mock('../../../events/functions/getNextPlayerId', () => ({
+  getNextPlayerId: jest.fn(() => 'player2'),
+}));
+jest.mock('../../../events/match/functions/generateAutomaticNumWinResponse', () => ({
+  generateAutomaticNumWinResponse: jest.fn(),
+}));
+jest.mock('../../../events/round/functions/startNewRound', () => ({
+  startNewRound: jest.fn(),
+}));
+jest.mock('../../../events/match/functions/endSpecialMatch', () => ({
+  endSpecialMatch: jest.fn(),
+}));
+
+function createLobbyInMatch(player: any) {
+  lobbys['123'] = {
+    lobbyId: '123',
+    players: [
+      {
+        id: player.playerId,
+        name: 'player1',
+        leader: true,
+        ready: false
+      },
+      {
+        id: 'player2',
+        name: 'player2',
+        leader: false,
+        ready: true
+      }
+    ],
+    game: {
+      matchNumber: 1,
+      roundNumber: 1,
+      currentPlayerId: player.playerId,
+      status: 'waiting_num_win_response',
+      deadPlayersIds: [],
+      numRounds: 2,
+      playersHealth: {},
+      timer: new Timer(),
+      match: {
+        players: {
+          [player.playerId]: { cards: [], numWinsNeeded: 0, numWonRounds: 0 },
+          'player2': { cards: [], numWinsNeeded: 0, numWonRounds: 0 }
+        },
+        nextPlayerId: player.playerId
+      }
+    }
+  };
+  player.lobby = lobbys['123'];
+  players[player.playerId] = { socket: player.socket, lobby: lobbys['123'] };
+  player.eventsEmitter = {
+    Match: {
+      emitWinRoundsNumberUpdate: emitWinRoundsNumberUpdate,
+      emitWinRoundsNumberError: emitWinRoundsNumberError
+    }
+  };
+}
+
+describe('handleWinRoundsNumberResponse', () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('Tentar palpitar sem estar em um lobby deve emitir erro', () => {
+    createLobbyInMatch(player);
+
+    player.lobby = undefined;
+    handleWinRoundsNumberResponse(player, 1);
+
+    expect(emitWinRoundsNumberError).toHaveBeenCalledWith('not-in-lobby');
+  });
+
+  test('Tentar palpitar sem estar em jogo deve emitir erro', () => {
+    createLobbyInMatch(player);
+
+    player.lobby!.game = undefined;
+    handleWinRoundsNumberResponse(player, 1);
+
+    expect(emitWinRoundsNumberError).toHaveBeenCalledWith('not-in-game');
+  });
+
+  test('Tentar palpitar sem estar em uma partida deve emitir erro', () => {
+    createLobbyInMatch(player);
+
+    player.lobby!.game!.match = undefined;
+    handleWinRoundsNumberResponse(player, 1);
+
+    expect(emitWinRoundsNumberError).toHaveBeenCalledWith('not-in-match');
+  });
+
+  test('Tentar palpitar fora de sua vez deve emitir erro', () => {
+    createLobbyInMatch(player);
+
+    player.lobby!.game!.match!.nextPlayerId = 'player2';
+    handleWinRoundsNumberResponse(player, 1);
+
+    expect(emitWinRoundsNumberError).toHaveBeenCalledWith('not-your-turn');
+  });
+
+  test('Tentar palpitar com número negativo deve emitir erro', () => {
+    createLobbyInMatch(player);
+
+    handleWinRoundsNumberResponse(player, -1);
+
+    expect(emitWinRoundsNumberError).toHaveBeenCalledWith('negative-is-invalid');
+  });
+
+  test('Tentar palpitar um valor inválido na última rodada deve emitir erro', () => {
+    (checkValidFinalGuess as jest.Mock).mockReturnValueOnce(false);
+
+    createLobbyInMatch(player);
+    handleWinRoundsNumberResponse(player, 1);
+
+    expect(emitWinRoundsNumberError).toHaveBeenCalledWith('num-wins-equals-num-cards');
+  });
+
+  test('Palpitar corretamente deve parar o timer antigo e atualizar o número de palpite do jogador atual no objeto Lobby', () => {
+    createLobbyInMatch(player);
+
+    const oldTimer = player.lobby!.game!.timer;
+
+    handleWinRoundsNumberResponse(player, 1);
+
+    expect(oldTimer.isRunning()).toBe(false);
+    expect(player.lobby?.game?.match?.players[player.playerId].numWinsNeeded).toBe(1);
+  });
+
+  test('Palpitar corretamente quando ainda existem jogadores a palpitar deve enviar mensagem com o palpite atual e o id do próximo jogador que deve palpitar. Também deve adicionar um timer para o palpite automático do próximo jogador. O status deve ser mantido "waiting_num_win_response"', () => {
+    (getNextPlayerId as jest.Mock).mockReturnValueOnce('player2'); // O player2 não é o primeiro jogador que palpitou. Ou seja, ainda não palpitaram todos os jogadores
+
+    createLobbyInMatch(player);
+
+    handleWinRoundsNumberResponse(player, 1);
+
+    expect(getNextPlayerId).toHaveBeenCalledWith(player.playerId, player.lobby!);
+    expect(emitWinRoundsNumberUpdate).toHaveBeenCalledWith(1, 'player2');
+
+    expect(player.lobby?.game?.match?.nextPlayerId).toBe('player2');
+    expect(player.lobby?.game?.status).toBe('waiting_num_win_response');
+
+    // Testing timer
+    expect(player.lobby?.game?.timer.getConfig().countdown).toBe(true);
+    expect(player.lobby?.game?.timer.getTimeValues().seconds).toBe(15);
+    jest.advanceTimersByTime(15000);
+    expect(generateAutomaticNumWinResponse).toHaveBeenCalledWith(player.lobby!);
+  });
+
+  test('Palpitar corretamente em uma partida comum quando é o último jogador a palpitar deve enviar a mensagem com o palpite e o próximo jogador indefinido. Também deve adicionar um timer para começar uma rodada. O status deve ser "starting_round"', () => {
+    (getNextPlayerId as jest.Mock).mockReturnValueOnce(player.playerId); // O player1 é o primeiro jogador que palpitou. Ou seja, se o próximo jogador for o player1, então todos os jogadores já palpitaram
+
+    createLobbyInMatch(player);
+
+    handleWinRoundsNumberResponse(player, 1);
+
+    expect(getNextPlayerId).toHaveBeenCalledWith(player.playerId, player.lobby!);
+    expect(emitWinRoundsNumberUpdate).toHaveBeenCalledWith(1, undefined);
+
+    expect(player.lobby?.game?.match?.nextPlayerId).toBe(undefined);
+    expect(player.lobby?.game?.status).toBe('starting_round');
+
+    // Testing timer
+    expect(player.lobby?.game?.timer.getConfig().countdown).toBe(true);
+    expect(player.lobby?.game?.timer.getTimeValues().seconds).toBe(5);
+    jest.advanceTimersByTime(5000);
+    expect(startNewRound).toHaveBeenCalledWith(player.lobby!);
+  });
+
+  test('Palpitar corretamente em uma partida especial quando é o último jogador a palpitar deve enviar a mensagem com o palpite e o próximo jogador indefinido. Também deve adicionar um timer para finalizar a partida especial. O status deve ser "ending_special_match"', () => {
+    (getNextPlayerId as jest.Mock).mockReturnValueOnce(player.playerId); // O player1 é o primeiro jogador que palpitou. Ou seja, se o próximo jogador for o player1, então todos os jogadores já palpitaram
+
+    createLobbyInMatch(player);
+    player.lobby!.game!.numRounds = 1;
+
+    handleWinRoundsNumberResponse(player, 1);
+
+    expect(getNextPlayerId).toHaveBeenCalledWith(player.playerId, player.lobby!);
+    expect(emitWinRoundsNumberUpdate).toHaveBeenCalledWith(1, undefined);
+
+    expect(player.lobby?.game?.match?.nextPlayerId).toBe(undefined);
+    expect(player.lobby?.game?.status).toBe('ending_special_match');
+
+    // Testing timer
+    expect(player.lobby?.game?.timer.getConfig().countdown).toBe(true);
+    expect(player.lobby?.game?.timer.getTimeValues().seconds).toBe(5);
+    jest.advanceTimersByTime(5000);
+    expect(endSpecialMatch).toHaveBeenCalledWith(player.lobby!);
+  });
+
+  test('Se ocorrer um erro ao coletar o próximo jogador, deve emitir um erro interno', () => {
+    (getNextPlayerId as jest.Mock).mockImplementationOnce(() => { throw new Error('getNextPlayerId error'); });
+
+    createLobbyInMatch(player);
+
+    handleWinRoundsNumberResponse(player, 1);
+
+    expect(generateInternalServerError).toHaveBeenCalledWith(player.lobby, new Error('getNextPlayerId error'));
+  });
+
+  test('Se ocorrer um erro ao verificar se o palpite final é válido, deve emitir um erro interno', () => {
+    (checkValidFinalGuess as jest.Mock).mockImplementationOnce(() => { throw new Error('checkValidFinalGuess error'); });
+
+    createLobbyInMatch(player);
+
+    handleWinRoundsNumberResponse(player, 1);
+
+    expect(generateInternalServerError).toHaveBeenCalledWith(player.lobby, new Error('checkValidFinalGuess error'));
+  });
+});

--- a/backend/src/events/game/functions/endGame.ts
+++ b/backend/src/events/game/functions/endGame.ts
@@ -1,14 +1,14 @@
-import Player from '../../../interfaces/Player';
+import Lobby from '../../../interfaces/Lobby';
 
 /**
  *  Função que finaliza uma jogo de "little-fuck". Essa função é responsável por:
  *  - Desenstanciar o Game
  *  - Enviar mensagens para todos os jogadores que o jogo finalizou
  *
- *  @param player um jogador qualquer que está na partida
+ *  @param lobby Objeto contendo informações do lobby
  */
 // Remover comentário abaixo quando implementar a função, juntamente com esse comentário atual
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function endGame(player: Player): void {
+export function endGame(lobby: Lobby): void {
 
 }

--- a/backend/src/events/match/functions/endMatch.ts
+++ b/backend/src/events/match/functions/endMatch.ts
@@ -1,5 +1,4 @@
 import Lobby from '../../../interfaces/Lobby';
-import Player from '../../../interfaces/Player';
 
 /**
  *  Função que finaliza uma partida de "little-fuck". Essa função é responsável por:

--- a/backend/src/events/match/functions/endMatch.ts
+++ b/backend/src/events/match/functions/endMatch.ts
@@ -1,3 +1,4 @@
+import Lobby from '../../../interfaces/Lobby';
 import Player from '../../../interfaces/Player';
 
 /**
@@ -6,10 +7,10 @@ import Player from '../../../interfaces/Player';
  *  - Enviar mensagens para todos os jogadores que a partida finalizou
  *  - Cadastrar um timer para o ínicio de uma nova partida ou para o fim de um jogo
  *
- *  @param player um jogador qualquer que está na partida
+ *  @param lobby Objeto contendo informações do lobby
  */
 // Remover comentário abaixo quando implementar a função, juntamente com esse comentário atual
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function endMatch(player: Player): void {
+export function endMatch(lobby: Lobby): void {
 
 }

--- a/backend/src/events/match/functions/endSpecialMatch.ts
+++ b/backend/src/events/match/functions/endSpecialMatch.ts
@@ -1,14 +1,14 @@
-import Player from '../../../interfaces/Player';
+import Lobby from '../../../interfaces/Lobby';
 
 /**
  *  Função que inicia a finalização de uma partida especial de "little-fuck". Essa função é responsável por:
  *  - Enviar mensagem para todos jogadores sobre a situação final da mesa (`table-update`)
  *  - Iniciar a finalização da partida especial (pela função `endRound`)
  *
- *  @param player um jogador qualquer que está na partida
+ *  @param lobby Objeto contendo informações do lobby
  */
 // Remover comentário abaixo quando implementar a função, juntamente com esse comentário atual
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function endSpecialMatch(player: Player): void {
+export function endSpecialMatch(lobby: Lobby): void {
 
 }

--- a/backend/src/events/match/handlers/winRoundsNumberResponse.ts
+++ b/backend/src/events/match/handlers/winRoundsNumberResponse.ts
@@ -1,4 +1,12 @@
+import Timer from 'easytimer.js';
 import Player from '../../../interfaces/Player';
+import { getNextPlayerId } from '../../functions/getNextPlayerId';
+import { generateInternalServerError } from '../../general/functions/generateInternalServerError';
+import { checkValidFinalGuess } from '../functions/checkValidFinalGuess';
+import { generateAutomaticNumWinResponse } from '../functions/generateAutomaticNumWinResponse';
+import Lobby from '../../../interfaces/Lobby';
+import { endSpecialMatch } from '../functions/endSpecialMatch';
+import { startNewRound } from '../../round/functions/startNewRound';
 
 /**
  *  Mensagem que o cliente enviará para indicar o seu palpite.
@@ -18,8 +26,75 @@ import Player from '../../../interfaces/Player';
  *  @param player Objeto contendo informações do jogador que acaba de chamar o evento
  *  @param numWinsRounds Número de rodadas que o jogador acha que irá vencer
  */
-// Remover comentário abaixo quando implementar a função, juntamente com esse comentário atual
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function handleWinRoundsNumberResponse(player: Player, numWinsRounds: number) {
+  if (!player.lobby) {
+    player.eventsEmitter.Match.emitWinRoundsNumberError('not-in-lobby');
+    return;
+  }
+  const lobby: Lobby = player.lobby;
 
+  if (!lobby.game) {
+    player.eventsEmitter.Match.emitWinRoundsNumberError('not-in-game');
+    return;
+  }
+
+  if (!lobby.game.match) {
+    player.eventsEmitter.Match.emitWinRoundsNumberError('not-in-match');
+    return;
+  }
+
+  if (!(player.playerId === lobby.game.match.nextPlayerId)) {
+    player.eventsEmitter.Match.emitWinRoundsNumberError('not-your-turn');
+    return;
+  }
+
+  if (numWinsRounds < 0) {
+    player.eventsEmitter.Match.emitWinRoundsNumberError('negative-is-invalid');
+    return;
+  }
+
+  try {
+    if (!checkValidFinalGuess(player.lobby, numWinsRounds)) {
+      player.eventsEmitter.Match.emitWinRoundsNumberError('num-wins-equals-num-cards');
+      return;
+    }
+
+    lobby.game.timer.stop();
+    lobby.game.timer = new Timer();
+
+    lobby.game.match.players[player.playerId].numWinsNeeded = numWinsRounds;
+
+    lobby.game.match.nextPlayerId = getNextPlayerId(lobby.game.match.nextPlayerId, lobby);
+
+    if (lobby.game.match.nextPlayerId === lobby.game.currentPlayerId) {
+      // O último jogador acabou de palpitar, hora de começar uma rodada ou finalizar a partida especial
+      lobby.game.match.nextPlayerId = undefined;
+      if (lobby.game.numRounds === 1) {
+        // Se tivermos apenas uma carta, então é uma partida especial. Nesse caso, precisamos finalizar a partida especial
+        lobby.game.status = 'ending_special_match';
+        lobby.game.timer.start({ countdown: true, startValues: { seconds: 5 } });
+        lobby.game.timer.addEventListener('targetAchieved', () => {
+          endSpecialMatch(lobby);
+        });
+      } else {
+        // Se tivermos mais de uma carta, então é uma partida normal. Nesse caso, precisamos começar uma rodada
+        lobby.game.status = 'starting_round';
+        lobby.game.timer.start({ countdown: true, startValues: { seconds: 5 } });
+        lobby.game.timer.addEventListener('targetAchieved', () => {
+          startNewRound(lobby);
+        });
+      }
+    } else {
+      // Ainda restam palpites a serem feitos... É preciso cadastrar o timer para palpite automático do próximo player
+      lobby.game.timer.start({ countdown: true, startValues: { seconds: 15 } });
+      lobby.game.timer.addEventListener('targetAchieved', () => {
+        generateAutomaticNumWinResponse(lobby);
+      });
+    }
+
+    player.eventsEmitter.Match.emitWinRoundsNumberUpdate(numWinsRounds, lobby.game.match.nextPlayerId);
+
+  } catch (error) {
+    generateInternalServerError(lobby, error as Error);
+  }
 }

--- a/backend/src/events/round/functions/endRound.ts
+++ b/backend/src/events/round/functions/endRound.ts
@@ -1,4 +1,4 @@
-import Player from '../../../interfaces/Player';
+import Lobby from '../../../interfaces/Lobby';
 
 /**
  *  Função que finaliza uma rodada de "little-fuck". Essa função é responsável por:
@@ -6,10 +6,10 @@ import Player from '../../../interfaces/Player';
  *  - Enviar mensagens para todos os jogadores que a rodada finalizou
  *  - Cadastrar um timer para o ínicio de uma nova rodada ou para o fim de uma partida (caso seja a última rodada)
  *
- *  @param player um jogador qualquer que está na partida
+ *  @param lobby Objeto contendo informações do lobby
  */
 // Remover comentário abaixo quando implementar a função, juntamente com esse comentário atual
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function endRound(player: Player): void {
+export function endRound(lobby: Lobby): void {
 
 }

--- a/backend/src/events/round/functions/startNewRound.ts
+++ b/backend/src/events/round/functions/startNewRound.ts
@@ -1,17 +1,16 @@
 
-import Player from '../../../interfaces/Player';
+import Lobby from '../../../interfaces/Lobby';
 
 /**
  *  Função que começa uma rodada de "little-fuck". Essa função é responsável por:
- *  - Criar um objeto Round (de forma in-place, ou seja, modifica o objeto `player.lobby` diretamente)
+ *  - Criar um objeto Round
  *  - Enviar mensagens para todos os jogadores que a rodada começou
  *  - Cadastrar um timer para que o primeiro jogador selecione a carta automaticamente caso ele não selecione a tempo
  *
- *  @param player um jogador qualquer que está na partida
- *  @returns um objeto do tipo Round, com as informações da partida que irá começar agora
+ *  @param lobby Objeto contendo informações do lobby
  */
 // Remover comentário abaixo quando implementar a função, juntamente com esse comentário atual
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function startNewRound(player: Player): void {
+export function startNewRound(lobby: Lobby): void {
 
 }


### PR DESCRIPTION
Além das implementações desta tarefa, foram feitos algumas mudanças extras:
- Trocar funções de começo e fim de jogo, partida e round para receber o lobby ao invés do player
- Correção de um teste que estava inicializando o servidor (ao importar index sem mockar)